### PR TITLE
Persist activities with SQLite and SQL migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@
 *.log
 *.sql
 *.sqlite
+*.db
+!src/migrations/*.sql
 
 # OS generated files #
 ######################

--- a/src/README.md
+++ b/src/README.md
@@ -6,6 +6,8 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- Persist activities and enrollments in a SQLite database
+- Automatic SQL migration execution on startup
 
 ## Getting Started
 
@@ -20,6 +22,11 @@ A super simple FastAPI application that allows students to view and sign up for 
    ```
    python app.py
    ```
+
+   On startup, the app automatically:
+   - Creates `src/data/school.db` if needed
+   - Runs unapplied SQL migrations from `src/migrations`
+   - Seeds default activities if the database is empty
 
 3. Open your browser and go to:
    - API documentation: http://localhost:8000/docs
@@ -47,4 +54,4 @@ The application uses a simple data model with meaningful identifiers:
    - Name
    - Grade level
 
-All data is stored in memory, which means data will be reset when the server restarts.
+Data is stored in SQLite, so activity and enrollment changes survive server restarts.

--- a/src/app.py
+++ b/src/app.py
@@ -11,6 +11,27 @@ from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
 
+try:
+    from .db import (
+        ActivityNotFoundError,
+        AlreadySignedUpError,
+        NotSignedUpError,
+        get_activities as get_activities_from_db,
+        initialize_database,
+        signup_for_activity as signup_for_activity_in_db,
+        unregister_from_activity as unregister_from_activity_in_db,
+    )
+except ImportError:
+    from db import (
+        ActivityNotFoundError,
+        AlreadySignedUpError,
+        NotSignedUpError,
+        get_activities as get_activities_from_db,
+        initialize_database,
+        signup_for_activity as signup_for_activity_in_db,
+        unregister_from_activity as unregister_from_activity_in_db,
+    )
+
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
 
@@ -19,63 +40,10 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-}
+
+@app.on_event("startup")
+def on_startup() -> None:
+    initialize_database()
 
 
 @app.get("/")
@@ -85,48 +53,36 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    return get_activities_from_db()
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
+    try:
+        signup_for_activity_in_db(activity_name, email)
+    except ActivityNotFoundError:
         raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is not already signed up
-    if email in activity["participants"]:
+    except AlreadySignedUpError:
         raise HTTPException(
             status_code=400,
             detail="Student is already signed up"
         )
 
-    # Add student
-    activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
+    try:
+        unregister_from_activity_in_db(activity_name, email)
+    except ActivityNotFoundError:
         raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is signed up
-    if email not in activity["participants"]:
+    except NotSignedUpError:
         raise HTTPException(
             status_code=400,
             detail="Student is not signed up for this activity"
         )
 
-    # Remove student
-    activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+
+BASE_DIR = Path(__file__).parent
+MIGRATIONS_DIR = BASE_DIR / "migrations"
+DATA_DIR = BASE_DIR / "data"
+DATABASE_PATH = DATA_DIR / "school.db"
+
+
+DEFAULT_ACTIVITIES: dict[str, dict[str, Any]] = {
+    "Chess Club": {
+        "description": "Learn strategies and compete in chess tournaments",
+        "schedule": "Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 12,
+        "participants": ["michael@mergington.edu", "daniel@mergington.edu"],
+    },
+    "Programming Class": {
+        "description": "Learn programming fundamentals and build software projects",
+        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+        "max_participants": 20,
+        "participants": ["emma@mergington.edu", "sophia@mergington.edu"],
+    },
+    "Gym Class": {
+        "description": "Physical education and sports activities",
+        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+        "max_participants": 30,
+        "participants": ["john@mergington.edu", "olivia@mergington.edu"],
+    },
+    "Soccer Team": {
+        "description": "Join the school soccer team and compete in matches",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 22,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"],
+    },
+    "Basketball Team": {
+        "description": "Practice and play basketball with the school team",
+        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["ava@mergington.edu", "mia@mergington.edu"],
+    },
+    "Art Club": {
+        "description": "Explore your creativity through painting and drawing",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"],
+    },
+    "Drama Club": {
+        "description": "Act, direct, and produce plays and performances",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"],
+    },
+    "Math Club": {
+        "description": "Solve challenging problems and participate in math competitions",
+        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 10,
+        "participants": ["james@mergington.edu", "benjamin@mergington.edu"],
+    },
+    "Debate Team": {
+        "description": "Develop public speaking and argumentation skills",
+        "schedule": "Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 12,
+        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"],
+    },
+}
+
+
+class ActivityNotFoundError(Exception):
+    pass
+
+
+class AlreadySignedUpError(Exception):
+    pass
+
+
+class NotSignedUpError(Exception):
+    pass
+
+
+def _get_connection() -> sqlite3.Connection:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(DATABASE_PATH)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    return connection
+
+
+def _apply_migrations(connection: sqlite3.Connection) -> None:
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+            version TEXT PRIMARY KEY,
+            applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+    applied = {
+        row["version"]
+        for row in connection.execute("SELECT version FROM schema_migrations").fetchall()
+    }
+
+    migration_files = sorted(MIGRATIONS_DIR.glob("*.sql"))
+    for migration_file in migration_files:
+        version = migration_file.name
+        if version in applied:
+            continue
+        script = migration_file.read_text(encoding="utf-8")
+        connection.executescript(script)
+        connection.execute(
+            "INSERT INTO schema_migrations(version) VALUES (?)",
+            (version,),
+        )
+
+
+def _seed_default_data(connection: sqlite3.Connection) -> None:
+    row = connection.execute("SELECT COUNT(*) AS count FROM activities").fetchone()
+    if row["count"] > 0:
+        return
+
+    for name, details in DEFAULT_ACTIVITIES.items():
+        cursor = connection.execute(
+            """
+            INSERT INTO activities(name, description, schedule, max_participants)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                name,
+                details["description"],
+                details["schedule"],
+                details["max_participants"],
+            ),
+        )
+        activity_id = cursor.lastrowid
+        for email in details["participants"]:
+            connection.execute(
+                "INSERT INTO enrollments(activity_id, email) VALUES (?, ?)",
+                (activity_id, email),
+            )
+
+
+def initialize_database() -> None:
+    with _get_connection() as connection:
+        _apply_migrations(connection)
+        _seed_default_data(connection)
+        connection.commit()
+
+
+def get_activities() -> dict[str, dict[str, Any]]:
+    with _get_connection() as connection:
+        rows = connection.execute(
+            """
+            SELECT
+                activities.id,
+                activities.name,
+                activities.description,
+                activities.schedule,
+                activities.max_participants,
+                enrollments.email
+            FROM activities
+            LEFT JOIN enrollments ON enrollments.activity_id = activities.id
+            ORDER BY activities.name, enrollments.email
+            """
+        ).fetchall()
+
+    activities: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        activity_name = row["name"]
+        if activity_name not in activities:
+            activities[activity_name] = {
+                "description": row["description"],
+                "schedule": row["schedule"],
+                "max_participants": row["max_participants"],
+                "participants": [],
+            }
+        if row["email"]:
+            activities[activity_name]["participants"].append(row["email"])
+
+    return activities
+
+
+def signup_for_activity(activity_name: str, email: str) -> None:
+    with _get_connection() as connection:
+        activity = connection.execute(
+            "SELECT id FROM activities WHERE name = ?",
+            (activity_name,),
+        ).fetchone()
+        if activity is None:
+            raise ActivityNotFoundError
+
+        existing = connection.execute(
+            "SELECT 1 FROM enrollments WHERE activity_id = ? AND email = ?",
+            (activity["id"], email),
+        ).fetchone()
+        if existing:
+            raise AlreadySignedUpError
+
+        connection.execute(
+            "INSERT INTO enrollments(activity_id, email) VALUES (?, ?)",
+            (activity["id"], email),
+        )
+        connection.commit()
+
+
+def unregister_from_activity(activity_name: str, email: str) -> None:
+    with _get_connection() as connection:
+        activity = connection.execute(
+            "SELECT id FROM activities WHERE name = ?",
+            (activity_name,),
+        ).fetchone()
+        if activity is None:
+            raise ActivityNotFoundError
+
+        deleted = connection.execute(
+            "DELETE FROM enrollments WHERE activity_id = ? AND email = ?",
+            (activity["id"], email),
+        )
+
+        if deleted.rowcount == 0:
+            raise NotSignedUpError
+
+        connection.commit()

--- a/src/migrations/001_create_activities_and_enrollments.sql
+++ b/src/migrations/001_create_activities_and_enrollments.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS activities (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE,
+    description TEXT NOT NULL,
+    schedule TEXT NOT NULL,
+    max_participants INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS enrollments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    activity_id INTEGER NOT NULL,
+    email TEXT NOT NULL,
+    FOREIGN KEY(activity_id) REFERENCES activities(id) ON DELETE CASCADE,
+    UNIQUE(activity_id, email)
+);
+
+CREATE INDEX IF NOT EXISTS idx_enrollments_activity_id ON enrollments(activity_id);


### PR DESCRIPTION
## Summary
Implements issue #8 by replacing in-memory activity storage with persistent SQLite-backed storage and startup migrations.

## What changed
- Added `src/db.py` with:
  - SQLite connection handling
  - migration application (`schema_migrations` tracking)
  - default activity seeding on first run
  - DB-backed functions for listing activities, signup, and unregister
- Added initial migration:
  - `src/migrations/001_create_activities_and_enrollments.sql`
  - creates `activities` and `enrollments` tables with constraints/index
- Updated `src/app.py`:
  - initialize database on startup
  - switched endpoints from in-memory dictionary to DB functions
  - preserved existing endpoint responses/error behavior
- Updated docs in `src/README.md` to describe persistence and migration flow
- Updated `.gitignore` to keep migration SQL tracked while ignoring local DB files

## Notes
- Data now persists across server restarts.
- Existing API contract remains unchanged for `/activities`, signup, and unregister routes.